### PR TITLE
Missing bus itinerary segments no longer deleted from itin table

### DIFF
--- a/MHN.py
+++ b/MHN.py
@@ -244,6 +244,47 @@ def ensure_dir(directory):
     return directory
 
 
+def find_shortest_path(graph, start, end, visited=None, distances=None, predecessors=None):
+    ''' Recursive function written by nolfonzo@gmail.com to find shortest path
+        between 2 nodes in a graph; implementation of Dijkstra's algorithm.
+        Based on <http://rebrained.com/?p=392>, accessed 9/2011.
+
+        Example graph dictionary (sub-dicts contain distances):
+
+            {'a': {'w': 14, 'x': 7, 'y': 9},
+             'b': {'w': 9, 'z': 6},
+             'w': {'a': 14, 'b': 9, 'y': 2},
+             'x': {'a': 7, 'y': 10, 'z': 15},
+             'y': {'a': 9, 'w': 2, 'x': 10, 'z': 11},
+             'z': {'b': 6, 'x': 15, 'y': 11}}
+    '''
+    if visited == None:
+        visited = []
+    if distances == None:
+        distances = {}
+    if predecessors == None:
+        predecessors = {}
+    if not visited:
+        distances[start] = 0  # Set distance to 0 for first pass
+    if start == end:  # We've found our end node, now find the path to it, and return
+        path = []
+        while end != None:
+            path.append(end)
+            end = predecessors.get(end, None)
+        return distances[start], path[::-1]
+    for neighbor in graph[start]:  # Process neighbors, keep track of predecessors
+        if neighbor not in visited:
+            neighbor_dist = distances.get(neighbor, float('infinity'))
+            tentative_dist = distances[start] + graph[start][neighbor]
+            if tentative_dist < neighbor_dist:
+                distances[neighbor] = tentative_dist
+                predecessors[neighbor] = start
+    visited.append(start)  # Mark the current node as visited
+    unvisiteds = dict((k, distances.get(k, float('infinity'))) for k in graph if k not in visited)  # Finds the closest unvisited node to the start
+    closest_node = min(unvisiteds, key=unvisiteds.get)
+    return find_shortest_path(graph, closest_node, end, visited, distances, predecessors)  # Start processing the closest node
+
+
 def get_yearless_hwyproj():
     ''' Check hwyproj completion years and return list of invalid projects'
         TIPIDs. '''

--- a/shortest_path.py
+++ b/shortest_path.py
@@ -2,20 +2,18 @@
 '''
     shortest_path.py
     Authors: cheither & npeterson
-    Revised: 5/6/13
+    Revised: 7/23/13
     ---------------------------------------------------------------------------
-    This script finds the shortest path between two nodes, given the available
-    network. The source of the shortest path function is:
-
-      <http://rebrained.com/?p=392> (accessed 09/2011) - author unknown
-
-    The function uses a brute force method to determine the shortest path: a
-    bit inelegant but effective.
+    This script finds the shortest path between two nodes, using a network
+    graph read in from a CSV. It is essentially a wrapper of the MHN module's
+    find_shortest_path() function, to facilitate calls from SAS programs.
 
 '''
 from __future__ import print_function
 import csv
 import sys
+# Do NOT import MHN and call MHN.find_shortest_path()! Importing MHN for each
+# anode-bnode pair takes *forever* when run outside of ArcGIS (i.e. from SAS).
 
 # -----------------------------------------------------------------------------
 #  Set parameters.
@@ -30,14 +28,27 @@ sys.setrecursionlimit(6000)  # Max. iterations (sys default = 1000)
 # -----------------------------------------------------------------------------
 #  Find shortest path.
 # -----------------------------------------------------------------------------
-graph = {}
-reader = csv.reader(open(link_dict_txt), delimiter='$')
-for row in reader:
-    graph[eval(row[0])] = eval(row[1]) # Assign key/value pairs
+# Use copy of find_shortest_path() from MHN.py to avoid costly arcpy imports:
+def find_shortest_path(graph, start, end, visited=None, distances=None, predecessors=None):
+    ''' Recursive function written by nolfonzo@gmail.com to find shortest path
+        between 2 nodes in a graph; implementation of Dijkstra's algorithm.
+        Based on <http://rebrained.com/?p=392>, accessed 9/2011.
 
-def shortestpath(graph, start, end, visited=[], distances={}, predecessors={}):
-    ''' Function written by unknown author to find shortest path between 2
-        nodes in a graph; implementation of Dijkstra's algorithm. '''
+        Example graph dictionary (sub-dicts contain distances):
+
+            {'a': {'w': 14, 'x': 7, 'y': 9},
+             'b': {'w': 9, 'z': 6},
+             'w': {'a': 14, 'b': 9, 'y': 2},
+             'x': {'a': 7, 'y': 10, 'z': 15},
+             'y': {'a': 9, 'w': 2, 'x': 10, 'z': 11},
+             'z': {'b': 6, 'x': 15, 'y': 11}}
+    '''
+    if visited == None:
+        visited = []
+    if distances == None:
+        distances = {}
+    if predecessors == None:
+        predecessors = {}
     if not visited:
         distances[start] = 0  # Set distance to 0 for first pass
     if start == end:  # We've found our end node, now find the path to it, and return
@@ -48,20 +59,25 @@ def shortestpath(graph, start, end, visited=[], distances={}, predecessors={}):
         return distances[start], path[::-1]
     for neighbor in graph[start]:  # Process neighbors, keep track of predecessors
         if neighbor not in visited:
-            neighbordist = distances.get(neighbor, sys.maxsize)
-            tentativedist = distances[start] + graph[start][neighbor]
-            if tentativedist < neighbordist:
-                distances[neighbor] = tentativedist
+            neighbor_dist = distances.get(neighbor, float('infinity'))
+            tentative_dist = distances[start] + graph[start][neighbor]
+            if tentative_dist < neighbor_dist:
+                distances[neighbor] = tentative_dist
                 predecessors[neighbor] = start
     visited.append(start)  # Mark the current node as visited
-    unvisiteds = dict((k, distances.get(k, sys.maxsize)) for k in graph if k not in visited)  # Finds the closest unvisited node to the start
-    closestnode = min(unvisiteds, key=unvisiteds.get)
-    return shortestpath(graph, closestnode, end, visited, distances, predecessors)  # Start processing the closest node
+    unvisiteds = dict((k, distances.get(k, float('infinity'))) for k in graph if k not in visited)  # Finds the closest unvisited node to the start
+    closest_node = min(unvisiteds, key=unvisiteds.get)
+    return find_shortest_path(graph, closest_node, end, visited, distances, predecessors)  # Start processing the closest node
 
-print(str(anode) + ',' + str(bnode))
+graph = {}
+reader = csv.reader(open(link_dict_txt), delimiter='$')
+for row in reader:
+    graph[eval(row[0])] = eval(row[1]) # Assign key/value pairs
 
-outFile = open(short_path_txt, 'a')
-outFile.write(str(shortestpath(graph, eval(anode), eval(bnode))) + '\n')
-outFile.close()
+print('Finding shortest path from {0} to {1}...'.format(anode, bnode))
+
+short_path = open(short_path_txt, 'a')
+short_path.write(str(find_shortest_path(graph, eval(anode), eval(bnode))) + '\n')
+short_path.close()
 
 print('DONE')


### PR DESCRIPTION
Missing segments will be kept in itinerary for reference only, but shortest_path will not be called to replace them (or to fill in the gap in the corresponding line feature). During transit file generation, however, shortest_path will be called and treats the invalid segments as gaps.
