### PR TITLE
Future Bus Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Thumbs.db
 # Misc #
 ########
 *.url
+.idea/

--- a/MHN.py
+++ b/MHN.py
@@ -45,6 +45,7 @@ class MasterHighwayNetwork(object):
         '100': 2010,  # WARNING: commenting-out 100 will adversely affect transit file generation for later scenarios
         '200': 2015,
         '300': 2020,  # No longer in use for conformity, as of C13Q3
+        #'300': 2017,  # Coming soon...
         '400': 2025,
         '500': 2030,
         '600': 2040

--- a/generate_transit_files.py
+++ b/generate_transit_files.py
@@ -2,7 +2,7 @@
 '''
     generate_transit_files.py
     Author: npeterson
-    Revised: 2/23/16
+    Revised: 12/12/16
     ---------------------------------------------------------------------------
     This program creates the Emme transit batchin files needed to model a
     scenario network. The scenario, output path and CT-RAMP flag are passed to
@@ -255,7 +255,9 @@ for scen in scen_list:
 
         # Export table of Park-n-Ride nodes
         pnr_view = 'pnr_view'
-        MHN.make_skinny_table_view(MHN.pnr, pnr_view, ['NODE', 'COST', 'SPACES'])
+        pnr_fields = ['NODE', 'COST', 'SPACES', 'SCENARIO']
+        pnr_sql = ''' "SCENARIO" LIKE '%{0}%' '''.format(scen[0])
+        MHN.make_skinny_table_view(MHN.pnr, pnr_view, pnr_fields, pnr_sql)
         pnr_csv = os.path.join(scen_tran_path, 'pnr.csv')
         MHN.write_attribute_csv(pnr_view, pnr_csv)
 
@@ -299,7 +301,10 @@ for scen in scen_list:
             bus_future_lyr = 'future_lyr'
             arcpy.MakeFeatureLayer_management(MHN.bus_future, bus_future_lyr)
             bus_future_id_field = MHN.route_systems[MHN.bus_future][1]
-            bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'VEHICLE_TYPE', 'SPEED', 'HEADWAY']
+            if abm_output:
+                bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'VEHICLE_TYPE', 'SPEED', 'HEADWAY']
+            else:
+                bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'CT_VEH', 'SPEED', 'HEADWAY']  # CT_VEH instead of VEHICLE_TYPE
             bus_future_query = ''' "SCENARIO" LIKE '%{0}%' '''.format(scen[0])  # SCENARIO field contains first character of applicable scenario codes
             bus_future_view = MHN.make_skinny_table_view(bus_future_lyr, 'bus_future_view', bus_future_attr, bus_future_query)
             bus_future_csv = os.path.join(scen_tran_path, 'bus_future.csv')

--- a/generate_transit_files.py
+++ b/generate_transit_files.py
@@ -2,7 +2,7 @@
 '''
     generate_transit_files.py
     Author: npeterson
-    Revised: 12/12/16
+    Revised: 12/13/16
     ---------------------------------------------------------------------------
     This program creates the Emme transit batchin files needed to model a
     scenario network. The scenario, output path and CT-RAMP flag are passed to
@@ -302,9 +302,9 @@ for scen in scen_list:
             arcpy.MakeFeatureLayer_management(MHN.bus_future, bus_future_lyr)
             bus_future_id_field = MHN.route_systems[MHN.bus_future][1]
             if abm_output:
-                bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'VEHICLE_TYPE', 'SPEED', 'HEADWAY']
-            else:
                 bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'CT_VEH', 'SPEED', 'HEADWAY']  # CT_VEH instead of VEHICLE_TYPE
+            else:
+                bus_future_attr = [bus_future_id_field, 'DESCRIPTION', 'MODE', 'VEHICLE_TYPE', 'SPEED', 'HEADWAY']
             bus_future_query = ''' "SCENARIO" LIKE '%{0}%' '''.format(scen[0])  # SCENARIO field contains first character of applicable scenario codes
             bus_future_view = MHN.make_skinny_table_view(bus_future_lyr, 'bus_future_view', bus_future_attr, bus_future_query)
             bus_future_csv = os.path.join(scen_tran_path, 'bus_future.csv')

--- a/generate_transit_files_2.sas
+++ b/generate_transit_files_2.sas
@@ -1,7 +1,7 @@
 /*
     generate_transit_files_2.sas
     authors: cheither & npeterson
-    revised: 1/6/16
+    revised: 12/13/16
     ----------------------------------------------------------------------------
     Program creates bus transit network batchin files. Bus transit network is
     built using a modified version of MHN processing procedures.
@@ -136,11 +136,11 @@ data routes; infile in1 dsd missover firstobs=2;
                 proc sort; by mode;  *** attach existing line headway for period;
             data rte2(drop=_type_ _freq_); merge rte2(in=hit) modeavg; by mode;
                 if hit;  *** attach average time period headway for mode;
-                
+
                 ** ## Final Time Period Headway Calculation ## **;
                 if headway > 0 then headway = headway * &hdwymult;  *** -- apply TOD headway multiplier to coded headway;
                 else headway = -1;  *** -- coded value of zero means use existing headways;
-                
+
                 if headway > 0 then do;               *** -- Priority 1: use coded headway (or existing headway, if shorter);
                     if exhdw > 0 then hfin = min(headway, exhdw);
                     else hfin = headway;
@@ -154,7 +154,7 @@ data routes; infile in1 dsd missover firstobs=2;
                 else if &tp = 5 then maxtime = 240;
                 else maxtime = 120;
                 hfin = min(hfin, maxtime);
-    
+
                 headway = round(hfin, 0.1);
 
             data routes(drop=new del keeptod exhdw modeavg hfin maxtime); set rte1 rte2;
@@ -200,7 +200,7 @@ data check; set check;
 
 data verify; set itins;
     proc sort; by itina itinb;
-    
+
 *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*;
 
 ** -- Adjust Itinerary Coding if it Contains Nodes not Available in the Network, If Necessary -- **;
@@ -274,8 +274,8 @@ data nodes; merge nodes(in=hit) ndzone; by itina;
     if hit;
 
 *** Join Park-n-Ride data to nodes;
-data pnr; infile pnrnd dsd missover firstobs=2;
-    input itina pcost pspac;
+data pnr (drop=scens); infile pnrnd dsd missover firstobs=2;
+    input itina pcost pspac scens;
     proc sort; by itina;
 data nodes; merge nodes pnr; by itina;
     if pcost = . then pcost = 0;
@@ -573,7 +573,7 @@ data chk; merge chk nodes(in=hit); by itina;
     if not hit;
     proc print; title "Still Bad Nodes";
 
-    
+
 *=====================================================================;
   ** CREATE MODE b (BusBusWalk) LINKS **;
 *=====================================================================;

--- a/import_future_bus_routes.py
+++ b/import_future_bus_routes.py
@@ -2,7 +2,7 @@
 '''
     import_future_bus_routes.py
     Author: npeterson
-    Revised: 9/2/14
+    Revised: 12/12/16
     ---------------------------------------------------------------------------
     Import future bus route coding from an Excel spreadsheet, with "header" and
     "itinerary" worksheets. SAS can currently only handle .xls and not .xlsx.
@@ -176,7 +176,7 @@ header_attr = {}
 
 route_fields = (
     common_id_field, 'DESCRIPTION', 'MODE', 'VEHICLE_TYPE', 'HEADWAY', 'SPEED',
-    'SCENARIO', 'REPLACE', 'TOD', 'NOTES'
+    'SCENARIO', 'REPLACE', 'TOD', 'NOTES', 'CT_VEH'
 )
 
 with open(future_route_csv, 'r') as raw_routes:

--- a/import_future_bus_routes_2.sas
+++ b/import_future_bus_routes_2.sas
@@ -1,7 +1,7 @@
 /*
    import_future_bus_routes_2.sas
    authors: cheither & npeterson
-   revised: 12/12/16
+   revised: 12/13/16
    ----------------------------------------------------------------------------
    Program is called by import_future_bus_routes.py and formats bus itineraries
    to build with arcpy.
@@ -75,7 +75,7 @@ data chk; set rte(where=(scenario in (.,0))); proc print; title "Scenario Values
 
 
     ** Replace File for ARC **;
-data rte; set rte (keep=tr_line des mode veh_type headway speed scenario replace tod nt);
+data rte; set rte (keep=tr_line des mode veh_type headway speed scenario replace tod nt ct_veh);
   label tr_line='TRANSIT_LINE'
         des='DESCRIPTION'
         mode='MODE'

--- a/import_future_bus_routes_2.sas
+++ b/import_future_bus_routes_2.sas
@@ -1,7 +1,7 @@
 /*
    import_future_bus_routes_2.sas
    authors: cheither & npeterson
-   revised: 7/18/14
+   revised: 12/12/16
    ----------------------------------------------------------------------------
    Program is called by import_future_bus_routes.py and formats bus itineraries
    to build with arcpy.
@@ -85,7 +85,8 @@ data rte; set rte (keep=tr_line des mode veh_type headway speed scenario replace
         scenario='SCENARIO'
         replace='REPLACE'
         tod='TOD'
-        nt='NOTES';
+        nt='NOTES'
+        ct_veh='CT_VEH';
    proc sort; by tr_line;
    proc export outfile=out1 dbms=csv label replace;
 


### PR DESCRIPTION
1. Resolves issue #84, where future bus routes were still being exported with non-ABM vehicle classes when running in ABM mode. The correct classes will now be applied.
2. Allows Park-n-Ride nodes to apply to a specific set of scenarios -- specified in the MHN geodatabase's **parknride** table -- rather than forcing them to be present in all scenarios.