### PR TITLE
Better bus scenario handling, new GTFS years

### DIFF
--- a/MHN.py
+++ b/MHN.py
@@ -2,7 +2,7 @@
 '''
     MHN.py
     Author: npeterson
-    Revised: 12/19/16
+    Revised: 12/20/16
     ---------------------------------------------------------------------------
     A class for importing into MHN processing scripts, containing frequently
     used methods and variables.
@@ -21,21 +21,24 @@ class MasterHighwayNetwork(object):
     # -----------------------------------------------------------------------------
     base_year = 2010  # BASELINK=1 network year, not necessarily scenario 100 (i.e. base_year was recently 2009, while scenario 100 was 2010)
 
-    bus_years = {'base': 2010, 'current': 2014}
+    bus_years = {
+        'base':    2015,
+        'current': 2016
+    }
 
     centroid_ranges = {
-        'CBD'    : xrange(   1,   48),  # NB. xrange(i,j) includes i & excludes j
+        'CBD':     xrange(   1,   48),  # NB. xrange(i,j) includes i & excludes j
         'Chicago': xrange(   1,  310),
-        'Cook'   : xrange(   1,  855),
+        'Cook':    xrange(   1,  855),
         'McHenry': xrange( 855,  959),
-        'Lake'   : xrange( 959, 1134),
-        'Kane'   : xrange(1134, 1279),
-        'DuPage' : xrange(1279, 1503),
-        'Will'   : xrange(1503, 1691),
+        'Lake':    xrange( 959, 1134),
+        'Kane':    xrange(1134, 1279),
+        'DuPage':  xrange(1279, 1503),
+        'Will':    xrange(1503, 1691),
         'Kendall': xrange(1691, 1712),
-        'CMAP'   : xrange(   1, 1712),
-        'MHN'    : xrange(   1, 1962),
-        'POE'    : xrange(1945, 1962)
+        'CMAP':    xrange(   1, 1712),
+        'MHN':     xrange(   1, 1962),
+        'POE':     xrange(1945, 1962)
     }
 
     min_node_id =  5001  # 1-5000 reserved for zone centroids/POEs
@@ -47,8 +50,7 @@ class MasterHighwayNetwork(object):
     scenario_years = {
         '100': 2010,  # WARNING: commenting-out 100 will adversely affect transit file generation for later scenarios
         '200': 2015,
-        '300': 2020,  # No longer in use for conformity, as of C13Q3
-        #'300': 2017,  # Coming soon...
+        '300': 2020,
         '400': 2025,
         '500': 2030,
         '600': 2040
@@ -58,21 +60,21 @@ class MasterHighwayNetwork(object):
     max_year = max((year for scen, year in scenario_years.iteritems()))
 
     tod_periods = {
-        '1' : ('8PM-6AM',                                   # 1: overnight
+        '1':  ('8PM-6AM',                                   # 1: overnight
                '"STARTHOUR" >= 20 OR "STARTHOUR" <= 5'),
-        '2' : ('6AM-7AM',                                   # 2: AM shoulder 1
+        '2':  ('6AM-7AM',                                   # 2: AM shoulder 1
                '"STARTHOUR" = 6'),
-        '3' : ('7AM-9AM',                                   # 3: AM peak
+        '3':  ('7AM-9AM',                                   # 3: AM peak
                '"STARTHOUR" IN (7, 8)'),
-        '4' : ('9AM-10AM',                                  # 4: AM shoulder 2
+        '4':  ('9AM-10AM',                                  # 4: AM shoulder 2
                '"STARTHOUR" = 9'),
-        '5' : ('10AM-2PM',                                  # 5: midday
+        '5':  ('10AM-2PM',                                  # 5: midday
                '"STARTHOUR" >= 10 AND "STARTHOUR" <= 13'),
-        '6' : ('2PM-4PM',                                   # 6: PM shoulder 1
+        '6':  ('2PM-4PM',                                   # 6: PM shoulder 1
                '"STARTHOUR" IN (14, 15)'),
-        '7' : ('4PM-6PM',                                   # 7: PM peak
+        '7':  ('4PM-6PM',                                   # 7: PM peak
                '"STARTHOUR" IN (16, 17)'),
-        '8' : ('6PM-8PM',                                   # 8: PM shoulder 2
+        '8':  ('6PM-8PM',                                   # 8: PM shoulder 2
                '"STARTHOUR" IN (18, 19)'),
         'am': ('7AM-9AM',                                   # am: Same as TOD 3, but for buses w/ >50% service in period
                '"AM_SHARE" >= 0.5')

--- a/generate_transit_files.py
+++ b/generate_transit_files.py
@@ -2,7 +2,7 @@
 '''
     generate_transit_files.py
     Author: npeterson
-    Revised: 12/13/16
+    Revised: 12/20/16
     ---------------------------------------------------------------------------
     This program creates the Emme transit batchin files needed to model a
     scenario network. The scenario, output path and CT-RAMP flag are passed to
@@ -111,9 +111,9 @@ bus_fc_dict = {MHN.bus_base: 'base',
                MHN.bus_current: 'current'}
 
 # Remove base or current from bus_fc_dict, if not used for specified scenarios.
-if not any(MHN.scenario_years[scen] <= MHN.bus_years['base'] for scen in scen_list):
+if not any(MHN.scenario_years[scen] < MHN.bus_years['current'] for scen in scen_list):
     del bus_fc_dict[MHN.bus_base]
-if not any(MHN.scenario_years[scen] > MHN.bus_years['base'] for scen in scen_list):
+if not any(MHN.scenario_years[scen] >= MHN.bus_years['current'] for scen in scen_list):
     del bus_fc_dict[MHN.bus_current]
 
 # Identify representative runs for bus_base and/or bus_current, as relevant.
@@ -203,7 +203,7 @@ if any(MHN.scenario_years[scen] > MHN.base_year for scen in scen_list):
 for scen in scen_list:
     # Set scenario-specific parameters.
     scen_year = MHN.scenario_years[scen]
-    if scen_year <= MHN.bus_years['base']:
+    if scen_year < MHN.bus_years['current']:
         bus_fc = MHN.bus_base
         which_bus = 'base'
     else:


### PR DESCRIPTION
Base GTFS year updated to 2015, in anticipation of model base year becoming 2015.
Current GTFS year updated to 2016.
Now scenario years earlier than "current" will use "base", and all other (later) scenarios will use "current".