### PR TITLE
Allow distance-based tolling

### DIFF
--- a/MHN.py
+++ b/MHN.py
@@ -2,7 +2,7 @@
 '''
     MHN.py
     Author: npeterson
-    Revised: 4/21/17
+    Revised: 5/4/17
     ---------------------------------------------------------------------------
     A class for importing into MHN processing scripts, containing frequently
     used methods and variables.
@@ -302,16 +302,16 @@ class MasterHighwayNetwork(object):
 
 
     @staticmethod
-    def determine_arc_bearing(line_feature):
+    def determine_arc_bearing(line_geom):
         ''' Determines the cardinal direction of a single arc, determined from its
             two endpoints. The angle is determined by the atan2() function, and
             after some numeric manipulation is then used to select the correct
             cardinal direction from an ordered list of possibilities. '''
         from math import atan2, degrees, floor
-        x1 = line_feature.firstPoint.X
-        y1 = line_feature.firstPoint.Y
-        x2 = line_feature.lastPoint.X
-        y2 = line_feature.lastPoint.Y
+        x1 = line_geom.firstPoint.X
+        y1 = line_geom.firstPoint.Y
+        x2 = line_geom.lastPoint.X
+        y2 = line_geom.lastPoint.Y
         xdiff = x2 - x1
         ydiff = y2 - y1
         angle = degrees(atan2(ydiff, xdiff))
@@ -327,6 +327,20 @@ class MasterHighwayNetwork(object):
         describe = arcpy.Describe(fc)
         OID_name = describe.OIDFieldName
         return OID_name
+
+
+    @staticmethod
+    def determine_tolltype(vdf, cost):
+        ''' Automatically determine TOLLTYPE code, based on link's VDF and
+            toll cost. '''
+        if cost > 0:
+            if vdf == '7':
+                tolltype = '1'  # Fixed cost toll (i.e. toll plaza)
+            else:
+                tolltype = '2'  # Per-mile rate (i.e. distance-based tolling)
+        else:
+            tolltype = '0'  # N/A (not tolled)
+        return tolltype
 
 
     @staticmethod

--- a/generate_highway_files_2.sas
+++ b/generate_highway_files_2.sas
@@ -1,7 +1,7 @@
 /*
     generate_highway_files_2.sas
     Authors: cheither, npeterson, nferguson & tschmidt
-    Revised: 4/24/17
+    Revised: 5/4/17
     ---------------------------------------------------------------------------
     Program uses base conditions and project data from the MHN to build Emme
     scenario highway networks. Emme batchin files are the output of this
@@ -368,7 +368,7 @@ data check; set emme2;
 
 ** VERIFY THAT EACH TOLL LINK HAS A TOLL AMOUNT **;
 data check; set emme2;
-    if (type1 = 7 and toll = 0) or (type1 ^= 7 and toll > 0);
+    if type1 = 7 and toll = 0;
     proc print; var anode bnode type1 toll;
     title "SUSPICIOUS TOLL CHARGES";
 
@@ -481,6 +481,14 @@ data coord; infile in4 dlm=',' dsd firstobs=2;
                 then mode = 'ASH';  ** No trucks;
             else if trkres in (12)
                 then mode = 'ASHTb';  ** No trucks except B-plates;
+        end;
+        
+    ** UPDATE TOLL COST FOR DISTANCE-BASED TOLL LINKS **;
+    ** Edit by NPeterson 5/4/2017 **;
+    data links&tod; set links&tod;
+        if toll > 0 and type1 ^= 7 then do;
+            toll = toll * miles;
+            toll = round(toll, 0.01);
         end;
 
     ** ATTACH COORDINATES TO NETWORK NODES **;

--- a/import_highway_projects.py
+++ b/import_highway_projects.py
@@ -2,7 +2,7 @@
 '''
     import_highway_projects.py
     Author: npeterson
-    Revised: 3/1/17
+    Revised: 5/5/17
     ---------------------------------------------------------------------------
     Import highway project coding from an Excel spreadsheet. SAS can currently
     only handle .xls and not .xlsx.
@@ -112,7 +112,7 @@ for project_id in project_arcs.keys():
 
     # Set COMPLETION_YEAR, MCP_ID & RSP_ID to defaults, or existing values if applicable.
     completion_year = 9999  # default 9999 (i.e. not conformed)
-    mcp_id = ' '            # default blank (i.e. not an MCP)
+    mcp_id = None           # default NULL (i.e. not an MCP)
     rsp_id = None           # default NULL (i.e. not an RSP)
     existing_project_query = ''' "{0}" = '{1}' '''.format(common_id_field, project_id)
     existing_project_lyr = MHN.make_skinny_table_view(MHN.hwyproj, 'existing_project_lyr', ['COMPLETION_YEAR', 'MCP_ID', 'RSP_ID'], existing_project_query)

--- a/incorporate_edits.py
+++ b/incorporate_edits.py
@@ -2,7 +2,7 @@
 '''
     incorporate_edits.py
     Author: npeterson
-    Revised: 12/19/16
+    Revised: 5/4/17
     ---------------------------------------------------------------------------
     This script should be run after any geometric edits have been made to the
     Master Highway Network. It will:
@@ -404,11 +404,21 @@ arcpy.AddMessage('-- Arc MILES field recalculated')
 with arcpy.da.UpdateCursor(temp_arcs, ['SHAPE@','BEARING']) as bearing_cursor:
     for arc in bearing_cursor:
         old_bearing = arc[1]
-        new_bearing = MHN.determine_arc_bearing(arc[0])
+        new_bearing = MHN.determine_arc_bearing(line_geom=arc[0])
         if new_bearing != old_bearing:
             arc[1] = new_bearing
             bearing_cursor.updateRow(arc)
 arcpy.AddMessage('-- Arc BEARING field recalculated')
+
+# Calculate arc TOLLTYPE values.
+with arcpy.da.UpdateCursor(temp_arcs, ['TOLLTYPE', 'TYPE1', 'TOLLDOLLARS']) as tolltype_cursor:
+    for arc in tolltype_cursor:
+        old_tolltype = arc[0]
+        new_tolltype = MHN.determine_tolltype(vdf=arc[1], cost=arc[2])
+        if new_tolltype != old_tolltype:
+            arc[0] = new_tolltype
+            tolltype_cursor.updateRow(arc)
+arcpy.AddMessage('-- Arc TOLLTYPE field recalculated')
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
From now on, the _TOLLDOLLARS_ attribute for any link where `TYPE1 <> '7'` is allowed to be nonzero and, in such cases, will be interpreted as a per-mile rate (multiplied by _MILES_ when Emme network files are generated).